### PR TITLE
Avoid duplicate processes and modify css under KDE.

### DIFF
--- a/indicator-stickynotes.py
+++ b/indicator-stickynotes.py
@@ -36,6 +36,10 @@ from locale import gettext as _
 from functools import wraps
 from shutil import copyfile, SameFileError
 
+import socket
+import sys
+import time
+
 def save_required(f):
     """Wrapper for functions that require a save after execution"""
     @wraps(f)
@@ -249,8 +253,16 @@ class IndicatorStickyNotes:
     def save(self):
         self.nset.save()
 
-
 def main():
+    # Avoid duplicate process
+    # From https://stackoverflow.com/questions/788411/check-to-see-if-python-script-is-running
+    procLock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        procLock.bind('\0' + 'indicator-stickynotes')
+    except socket.error:
+        print('Indicator stickynotes already running.')
+        sys.exit()
+
     try:
         locale.setlocale(locale.LC_ALL, '')
     except:

--- a/style.css
+++ b/style.css
@@ -23,6 +23,13 @@
     background-color: $bgcolor_hex;
     color: $text_color;
 }
+
+#txt-note text
+{
+    color: $text_color;
+    background-color: transparent;
+}
+
 #txt-note text selection
 {
     color: $bgcolor_hex;

--- a/style_global.css
+++ b/style_global.css
@@ -18,7 +18,7 @@
  * 
  */
 
-GtkSourceView, GtkButton, GtkEventBox
+GtkSourceView, GtkButton, GtkEventBox, text
 {
-    background:transparent;
+    background: transparent;
 }

--- a/style_global.css
+++ b/style_global.css
@@ -18,7 +18,7 @@
  * 
  */
 
-GtkSourceView, GtkButton, GtkEventBox, text
+GtkSourceView, GtkButton, GtkEventBox
 {
     background: transparent;
 }


### PR DESCRIPTION
I love this app but experience some problems under Kubuntu 18.04.1.
KDE runs duplicate indicator stickynotes on startup and re-login.
Notes' appearance seems broken, and text color can't be changed.
So I modify some code and css to deal with these problems.

Before:
![screenshot_20180819_001429](https://user-images.githubusercontent.com/28639476/44319997-f72d4900-a471-11e8-8e16-5165562ea294.png)

After:
![screenshot_20180819_001328](https://user-images.githubusercontent.com/28639476/44320006-fe545700-a471-11e8-8422-37202a22fdb1.png)

Tested under:
 - Ubuntu 18.04.1 (Gnome)
 - Kubuntu 18.04.1 (KDE)