### PR TITLE
Add archive functionality for deleted notes

### DIFF
--- a/indicator-stickynotes.py
+++ b/indicator-stickynotes.py
@@ -142,6 +142,15 @@ class IndicatorStickyNotes:
         self.menu.append(s)
         s.show()
 
+        self.mArchive = Gtk.MenuItem(_("Archive"))
+        self.menu.append(self.mArchive)
+        self.mArchive.connect("activate", self.show_archive, None)
+        self.mArchive.show()
+
+        s = Gtk.SeparatorMenuItem.new()
+        self.menu.append(s)
+        s.show()
+
         self.mAbout = Gtk.MenuItem(_("About"))
         self.menu.append(self.mAbout)
         self.mAbout.connect("activate", self.show_about, None)
@@ -248,6 +257,10 @@ class IndicatorStickyNotes:
 
     def show_settings(self, *args):
         wSettings = SettingsDialog(self.nset)
+
+    def show_archive(self, *args):
+        from stickynotes.gui import ArchiveDialog
+        ArchiveDialog(self.nset)
 
     def save(self):
         self.nset.save()

--- a/stickynotes/info.py
+++ b/stickynotes/info.py
@@ -9,3 +9,7 @@ FALLBACK_PROPERTIES = { "bgcolor_hsv": [48./360, 1, 1],
                         "textcolor": [32./255, 32./255, 32./255],
                         "font": "",
                         "shadow": 60}
+
+# Archive settings (default values)
+DEFAULT_TRASH_RETENTION_DAYS = 30
+DEFAULT_CONFIRM_DELETE = False


### PR DESCRIPTION
Features:
- Notes are moved to archive instead of permanent deletion
- Configurable retention period (default: 30 days, 0 = forever)
- Optional delete confirmation dialog (disabled by default)
- Archive viewer with restore and permanent delete options
- Auto-cleanup of old archived notes on startup

Changes:
- stickynotes/info.py: Add default settings for archive
- stickynotes/backend.py: Implement archive storage and management
- stickynotes/gui.py: Add ArchiveDialog and settings UI
- indicator-stickynotes.py: Add 'Archive' menu item

Closes: Note recovery feature request